### PR TITLE
disable blockipupd script

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -1,3 +1,4 @@
+name: "Pre-commit"
 on:
   push: {}
   pull_request: {}

--- a/.github/workflows/run-molecule.yml
+++ b/.github/workflows/run-molecule.yml
@@ -1,6 +1,7 @@
+name: "Molecule"
 on:
   push: {}
-  pull-request: {}
+  pull_request: {}
   workflow_dispatch: {}
 
 jobs:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -20,3 +20,25 @@
         owner: root
         group: root
         mode: "0440"
+
+    - name: create fake crontab
+      copy:
+        dest: /etc/crontab
+        content: |
+          SHELL=/bin/bash
+          PATH=/sbin:/bin:/usr/sbin:/usr/bin
+          MAILTO=root
+
+          # For details see man 4 crontabs
+
+          # Example of job definition:
+          # .---------------- minute (0 - 59)
+          # |  .------------- hour (0 - 23)
+          # |  |  .---------- day of month (1 - 31)
+          # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+          # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+          # |  |  |  |  |
+          # *  *  *  *  * user-name  command to be executed
+
+          */5 * * * * root /root/checkdb
+          */5 * * * * root docker ps|grep massopen &>/dev/null || /etc/scripts/firewall

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -38,7 +38,24 @@
       quiet: true
     loop:
       - >-
-        -A moc_input -p tcp -s 129.10.5.0/24  --dport 22  -m state --state NEW -m comment --comment "ssh_moc"
+        -A moc_input -p tcp -s 129.10.5.0/24  --dport 22  -m state --state NEW -m comment --comment "ssh_moc" -j ACCEPT
       - >-
-        -A moc_input -p tcp -s 192.12.185.0/24  --dport 22  -m state --state NEW -m comment --comment "ssh_moc"
+        -A moc_input -p tcp -s 192.12.185.0/24  --dport 22  -m state --state NEW -m comment --comment "ssh_moc" -j ACCEPT
 
+  - name: get content of /etc/crontab
+    command: cat /etc/crontab
+    register: crontab
+
+  - name: check contents of crontab
+    assert:
+      that: >-
+        "/etc/scripts/firewall" not in crontab.stdout
+
+  - name: check for blockipupd cronjob
+    stat:
+      path: /etc/cron.daily/blockipupd
+    register: blockipupd
+
+  - name: verify that blockipupd cronjob is absent
+    assert:
+      that: not blockipupd.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,25 @@
 ---
 - name: disable legacy firewall script
+  tags: [legacy]
+  become: true
   lineinfile:
     path: /etc/rc.local
     line: /etc/scripts/firewall
+    state: absent
+
+- name: disable legacy blockipupd script
+  tags: [legacy]
+  become: true
+  file:
+    path: /etc/cron.daily/blockipupd
+    state: absent
+
+- name: disable firewall changes from crontab
+  tags: [legacy]
+  become: true
+  lineinfile:
+    path: /etc/crontab
+    regexp: /etc/scripts/firewall
     state: absent
 
 - name: install packages
@@ -23,7 +40,7 @@
 
 - name: enable iptables service
   become: true
-  tags: [notest,service]
+  tags: [notest, service]
   service:
     name: iptables
     enabled: true


### PR DESCRIPTION
There is a cron job that runs the `blockipupd` script on a daily
schedule; this script runs the legacy firewall script so it reverts
all of our firewall changes.
