### PR TITLE
Fix firewall issues impacting adjutant

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ iptables_packages:
 
 fw_log_rejects: false
 fw_reload_mode: flag
+fw_primary_interface: eth0

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,7 +24,9 @@ provisioner:
         moc_control_hosts:
           - 127.0.0.100
         fw_enabled_services:
+          - web
           - ssh_moc
+          - mysql_local
 verifier:
   name: ansible
 lint: |

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -43,6 +43,14 @@
           */5 * * * * root /root/checkdb
           */5 * * * * root docker ps|grep massopen &>/dev/null || /etc/scripts/firewall
 
+    - name: create /etc/cron.daily directory
+      file:
+        path: /etc/cron.daily
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+
     - name: create fake blockipupd script
       copy:
         dest: /etc/cron.daily/blockipupd

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -32,7 +32,7 @@
         "-A moc_control_hosts -s 127.0.0.100 -j ACCEPT"
         in config.stdout_lines
 
-  - name: check for moc_ssh rules
+  - name: check for iptables rules
     assert:
       that: item in config.stdout_lines
       quiet: true
@@ -41,6 +41,14 @@
         -A moc_input -p tcp -s 129.10.5.0/24  --dport 22  -m state --state NEW -m comment --comment "ssh_moc" -j ACCEPT
       - >-
         -A moc_input -p tcp -s 192.12.185.0/24  --dport 22  -m state --state NEW -m comment --comment "ssh_moc" -j ACCEPT
+      - >-
+        -A moc_input -p tcp -s 128.31.28.0/24  --dport 22  -m state --state NEW -m comment --comment "ssh_moc" -j ACCEPT
+      - >-
+        -A moc_input -p tcp --dport 3306 ! -i eth0 -j ACCEPT -m comment --comment "mysql_local"
+      - >-
+        -A moc_input -p tcp   --dport 80  -m state --state NEW -m comment --comment "web" -j ACCEPT
+      - >-
+        -A moc_input -p tcp   --dport 443  -m state --state NEW -m comment --comment "web" -j ACCEPT
 
   - name: get content of /etc/crontab
     command: cat /etc/crontab

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,8 @@ fw_services:
         dport: 22
       - srcip: 192.12.185.0/24
         dport: 22
+      - srcip: 128.31.28.0/24
+        dport: 22
   all_internal_nets:
     filter_INPUT:
       - srcip: 10.0.0.0/8
@@ -58,4 +60,4 @@ fw_services:
   mysql_local:
     filter_INPUT_raw:
       - >-
-        -p tcp --dport 3306 ! -i {{ fw_primary_interface }}
+        -p tcp --dport 3306 ! -i {{ fw_primary_interface }} -j ACCEPT

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -50,3 +50,12 @@ fw_services:
   zabbix:
     filter_INPUT:
       - dport: 10050
+
+  # For hosts running containerized services, but MySQL on the host, we need
+  # to permit connections from "everywhere that is not the primary interface"
+  # (because we don't know in advance the source ip or even the cidr range of
+  # the containerized services).
+  mysql_local:
+    filter_INPUT_raw:
+      - >-
+        -p tcp --dport 3306 ! -i {{ fw_primary_interface }}


### PR DESCRIPTION
- Adds a "mysql_local" service that permits access to MySQL from
  anywhere other than the primary interface.

- Add 128.31.28.0/24 to ssh_moc rule

Part of cci-moc/ops-issues#278
