### PR TITLE
Add support for a post-firewall-reload script

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,6 +13,14 @@
     - reload iptables
   command: iptables-restore /etc/sysconfig/iptables
 
+- name: "reload running firewall: post"
+  become: true
+  when: >-
+    fw_reload_mode == "live" and fw_reload_post is defined
+  listen:
+    - reload iptables
+  command: "{{ fw_reload_post }}"
+
 - name: flag reboot
   become: true
   when: >-


### PR DESCRIPTION
This can be used to run a custom per-host or per-group script after
reloading the firewall. We can use this e.g. on the sso servers to
reload docker.
